### PR TITLE
[MNT] Update netneurotools version requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 
 |
-   
+
 .. image:: https://zenodo.org/badge/710175458.svg
   :target: https://zenodo.org/doi/10.5281/zenodo.10583040
   :alt: Zenodo DOI
@@ -8,7 +8,7 @@
 .. image:: https://github.com/SNG-newy/eigenstrapping/actions/workflows/tests.yml/badge.svg
   :target: https://github.com/SNG-newy/eigenstrapping/actions/workflows/tests.yml
   :alt: run-tests status
-   
+
 .. image:: https://github.com/SNG-newy/eigenstrapping/actions/workflows/docs.yml/badge.svg
   :target: https://eigenstrapping.readthedocs.io/en/latest/
   :alt: deploy-docs status
@@ -59,10 +59,10 @@ To run eigenstrapping, the following Python packages are required (these should 
 * `nilearn <https://nilearn.github.io/>`_
 * `pandas <https://pandas.pydata.org/>`_
 * `brainspace <https://github.com/MICA-MNI/BrainSpace/tree/master/>`_
-* netneurotools - note: the latest version must be installed directly from this `link here <https://github.com/nikitas-k/netneurotools_scipyfix>`_
+* `netneurotools <https://github.com/netneurolab/netneurotools>`_
 
-``nibabel`` and ``nilearn`` are required for surfaces and volumes. ``matplotlib`` 
-is only required for fitting plots in :mod:`eigenstrapping.fit` and some of the surface 
+``nibabel`` and ``nilearn`` are required for surfaces and volumes. ``matplotlib``
+is only required for fitting plots in :mod:`eigenstrapping.fit` and some of the surface
 plotting functions. Future improvements will reduce the number of dependencies
 needed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
 ]
 install_requires = [
-  "netneurotools @ git+https://github.com/nikitas-k/netneurotools-scipyfix.git@main"
+  "netneurotools>=0.2.4"
 ]
 
 
@@ -33,7 +33,7 @@ dependencies = [
   "scipy>=0.11",
   "seaborn",
   "tqdm",
-  "netneurotools @ git+https://github.com/nikitas-k/netneurotools_scipyfix.git@main"
+  "netneurotools>=0.2.4"
 ]
 maintainers = [
   {name = "Systems Neuroscience Group Newcastle", email = "nikitas.koussis@gmail.com"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pandas
 scipy>=0.11
 seaborn
 tqdm
-netneurotools @ git+https://github.com/nikitas-k/netneurotools_scipyfix.git@main
+netneurotools>=0.2.4


### PR DESCRIPTION
We released a new version of netneurotools a couple of months ago 😄 ([0.2.4](https://github.com/netneurolab/netneurotools/releases/tag/0.2.4)). So this toolbox should now work with the pip version of netneurotools! 